### PR TITLE
ci: skip CI on release-please branches

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -6,6 +6,8 @@ env:
 
 on:
   push:
+    branches-ignore:
+      - 'release-please--**'
 
 jobs:
   unit_test:


### PR DESCRIPTION
Release-please PRs only contain changelog/version bumps, so running the
full test suite on them is wasted work. Filter the push trigger to
ignore release-please-- branches.