### PR TITLE
style: black-and-white redesign with Apple-style polish

### DIFF
--- a/app/components/footer/Footer.test.tsx
+++ b/app/components/footer/Footer.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Footer from './Footer';
+
+describe('Footer', () => {
+  it('renders GitHub and LinkedIn pills with correct external link attributes', () => {
+    render(<Footer />);
+
+    const github = screen.getByRole('link', { name: 'GitHub' });
+    const linkedin = screen.getByRole('link', { name: 'LinkedIn' });
+
+    expect(github).toHaveAttribute('href', 'https://github.com/matthew-a-carr');
+    expect(linkedin).toHaveAttribute(
+      'href',
+      'https://www.linkedin.com/in/matthew-carr-17012284',
+    );
+
+    for (const link of [github, linkedin]) {
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    }
+  });
+});

--- a/app/components/footer/Footer.tsx
+++ b/app/components/footer/Footer.tsx
@@ -4,12 +4,12 @@ import { FaGithub, FaLinkedin } from 'react-icons/fa';
 const icons = [
   {
     href: 'https://github.com/matthew-a-carr',
-    icon: <FaGithub className="w-8 h-8" />,
+    icon: <FaGithub className="w-4 h-4" />,
     label: 'GitHub',
   },
   {
     href: 'https://www.linkedin.com/in/matthew-carr-17012284',
-    icon: <FaLinkedin className="w-8 h-8" />,
+    icon: <FaLinkedin className="w-4 h-4" />,
     label: 'LinkedIn',
   },
 ];
@@ -31,9 +31,9 @@ const FooterIcon: FunctionComponent<FooterIconProps> = ({
     target="_blank"
     rel="noopener noreferrer"
     aria-label={label}
-    className="group inline-flex items-center gap-3 rounded-full border border-[color:var(--border)] bg-[color:var(--surface)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--fg)] shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-[color:var(--accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]"
+    className="group inline-flex items-center gap-3 rounded-full border border-[color:var(--border)] bg-white px-5 py-2.5 text-[13px] font-medium tracking-tight text-[color:var(--fg)] transition-all duration-300 hover:-translate-y-0.5 hover:border-[color:var(--border-strong)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--fg)]"
   >
-    <span className="text-[color:var(--accent)]">{icon}</span>
+    <span className="text-[color:var(--fg)]">{icon}</span>
     <span>{label}</span>
   </a>
 );

--- a/app/components/footer/Footer.tsx
+++ b/app/components/footer/Footer.tsx
@@ -33,7 +33,9 @@ const FooterIcon: FunctionComponent<FooterIconProps> = ({
     aria-label={label}
     className="group inline-flex items-center gap-3 rounded-full border border-[color:var(--border)] bg-white px-5 py-2.5 text-[13px] font-medium tracking-tight text-[color:var(--fg)] transition-all duration-300 hover:-translate-y-0.5 hover:border-[color:var(--border-strong)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--fg)]"
   >
-    <span className="text-[color:var(--fg)]">{icon}</span>
+    <span aria-hidden="true" className="text-[color:var(--fg)]">
+      {icon}
+    </span>
     <span>{label}</span>
   </a>
 );

--- a/app/components/reveal/RevealOnScroll.test.tsx
+++ b/app/components/reveal/RevealOnScroll.test.tsx
@@ -1,0 +1,135 @@
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import RevealOnScroll from './RevealOnScroll';
+
+type Cb = (
+  entries: Pick<IntersectionObserverEntry, 'isIntersecting' | 'target'>[],
+) => void;
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+  callback: Cb;
+  observed: Element[] = [];
+  disconnect = vi.fn();
+  unobserve = vi.fn((el: Element) => {
+    this.observed = this.observed.filter((o) => o !== el);
+  });
+  takeRecords = vi.fn(() => []);
+  root = null;
+  rootMargin = '';
+  thresholds = [];
+
+  constructor(cb: Cb) {
+    this.callback = cb;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+
+  trigger(target: Element, isIntersecting = true) {
+    this.callback([{ isIntersecting, target }]);
+  }
+}
+
+const SCENE = (
+  <>
+    <div className="reveal" data-testid="a" />
+    <div className="reveal" data-testid="b" />
+  </>
+);
+
+const originalIO = global.IntersectionObserver;
+
+describe('RevealOnScroll', () => {
+  beforeEach(() => {
+    MockIntersectionObserver.instances = [];
+    (
+      global as unknown as { IntersectionObserver: typeof IntersectionObserver }
+    ).IntersectionObserver =
+      MockIntersectionObserver as unknown as typeof IntersectionObserver;
+  });
+
+  afterEach(() => {
+    (
+      global as unknown as {
+        IntersectionObserver: typeof IntersectionObserver | undefined;
+      }
+    ).IntersectionObserver = originalIO;
+  });
+
+  it('observes every .reveal element on mount', () => {
+    render(
+      <>
+        {SCENE}
+        <RevealOnScroll />
+      </>,
+    );
+
+    const [observer] = MockIntersectionObserver.instances;
+    expect(observer.observed).toHaveLength(2);
+  });
+
+  it('adds in-view to intersecting elements and unobserves them', () => {
+    const { getByTestId } = render(
+      <>
+        {SCENE}
+        <RevealOnScroll />
+      </>,
+    );
+
+    const [observer] = MockIntersectionObserver.instances;
+    const target = getByTestId('a');
+
+    expect(target.classList.contains('in-view')).toBe(false);
+    observer.trigger(target, true);
+    expect(target.classList.contains('in-view')).toBe(true);
+    expect(observer.unobserve).toHaveBeenCalledWith(target);
+  });
+
+  it('does not add in-view when the entry is not intersecting', () => {
+    const { getByTestId } = render(
+      <>
+        {SCENE}
+        <RevealOnScroll />
+      </>,
+    );
+
+    const [observer] = MockIntersectionObserver.instances;
+    const target = getByTestId('b');
+    observer.trigger(target, false);
+
+    expect(target.classList.contains('in-view')).toBe(false);
+  });
+
+  it('disconnects the observer on unmount', () => {
+    const { unmount } = render(
+      <>
+        {SCENE}
+        <RevealOnScroll />
+      </>,
+    );
+
+    const [observer] = MockIntersectionObserver.instances;
+    unmount();
+    expect(observer.disconnect).toHaveBeenCalled();
+  });
+
+  it('falls back to revealing everything when IntersectionObserver is unsupported', () => {
+    // The component checks via `'IntersectionObserver' in window`, so the
+    // property must actually be removed (not just set to undefined).
+    delete (window as unknown as { IntersectionObserver?: unknown })
+      .IntersectionObserver;
+
+    const { getByTestId } = render(
+      <>
+        {SCENE}
+        <RevealOnScroll />
+      </>,
+    );
+
+    expect(getByTestId('a').classList.contains('in-view')).toBe(true);
+    expect(getByTestId('b').classList.contains('in-view')).toBe(true);
+  });
+});

--- a/app/components/reveal/RevealOnScroll.tsx
+++ b/app/components/reveal/RevealOnScroll.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function RevealOnScroll() {
+  useEffect(() => {
+    const elements = document.querySelectorAll<HTMLElement>('.reveal');
+    if (!('IntersectionObserver' in window)) {
+      for (const el of elements) {
+        el.classList.add('in-view');
+      }
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('in-view');
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      { rootMargin: '0px 0px -10% 0px', threshold: 0.08 },
+    );
+    for (const el of elements) {
+      observer.observe(el);
+    }
+    return () => observer.disconnect();
+  }, []);
+
+  return null;
+}

--- a/app/components/technical-skills/TechnicalSkills.test.tsx
+++ b/app/components/technical-skills/TechnicalSkills.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import TechnicalSkills from './TechnicalSkills';
+
+const expectedSkills = [
+  'Java',
+  'Spring Boot',
+  'Kotlin',
+  'PostgreSQL',
+  'MySQL',
+  'MongoDB',
+  'Snowflake',
+  'Terraform',
+  'Docker',
+  'JavaScript',
+  'TypeScript',
+  'Cypress',
+  'Angular',
+  'React',
+  'NextJS',
+  'AWS',
+  'Azure',
+  'GCP',
+];
+
+describe('TechnicalSkills', () => {
+  it('renders every skill chip', () => {
+    render(<TechnicalSkills />);
+
+    for (const name of expectedSkills) {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    }
+  });
+
+  it('renders each skill exactly once', () => {
+    render(<TechnicalSkills />);
+
+    for (const name of expectedSkills) {
+      expect(screen.getAllByText(name)).toHaveLength(1);
+    }
+  });
+});

--- a/app/components/technical-skills/TechnicalSkills.tsx
+++ b/app/components/technical-skills/TechnicalSkills.tsx
@@ -99,16 +99,14 @@ const TechnicalSkills: FunctionComponent = () => (
     {skills.map((skill) => (
       <div
         key={skill.name}
-        className="group rounded-2xl border border-[color:var(--border)] bg-[color:var(--surface)] p-4 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[color:var(--accent)]"
+        className="group flex items-center gap-3 rounded-2xl border border-[color:var(--border)] bg-white p-4 transition-all duration-300 hover:-translate-y-1 hover:border-[color:var(--border-strong)] hover:shadow-[0_12px_36px_-20px_rgba(0,0,0,0.18)]"
       >
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-[color:var(--border)] bg-[color:var(--surface-alt)] text-[color:var(--accent)]">
-            {skill.icon}
-          </div>
-          <span className="text-sm font-medium text-[color:var(--fg)]">
-            {skill.name}
-          </span>
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[color:var(--fg)] text-white transition-colors group-hover:bg-black">
+          {skill.icon}
         </div>
+        <span className="text-[14px] font-medium tracking-tight text-[color:var(--fg)]">
+          {skill.name}
+        </span>
       </div>
     ))}
   </>

--- a/app/components/technical-skills/TechnicalSkills.tsx
+++ b/app/components/technical-skills/TechnicalSkills.tsx
@@ -101,7 +101,10 @@ const TechnicalSkills: FunctionComponent = () => (
         key={skill.name}
         className="group flex items-center gap-3 rounded-2xl border border-[color:var(--border)] bg-white p-4 transition-all duration-300 hover:-translate-y-1 hover:border-[color:var(--border-strong)] hover:shadow-[0_12px_36px_-20px_rgba(0,0,0,0.18)]"
       >
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[color:var(--fg)] text-white transition-colors group-hover:bg-black">
+        <div
+          aria-hidden="true"
+          className="flex h-10 w-10 items-center justify-center rounded-xl bg-[color:var(--fg)] text-white transition-colors group-hover:bg-black"
+        >
           {skill.icon}
         </div>
         <span className="text-[14px] font-medium tracking-tight text-[color:var(--fg)]">

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,8 +20,8 @@
   --bg-elevated: #ffffff;
   --fg: #000000;
   --fg-strong: #000000;
-  --muted: #86868b;
-  --soft: #515154;
+  --muted: #5e5e62;
+  --soft: #424246;
   --surface: #fbfbfd;
   --surface-alt: #f5f5f7;
   --surface-strong: #1d1d1f;
@@ -92,11 +92,18 @@ body {
   transition-delay: 0.32s;
 }
 
-/* Apple-style header backdrop blur */
+/* Apple-style header — solid white so content underneath never bleeds
+   through the sticky surface. backdrop-filter is layered on as an
+   enhancement when the underlying renderer honors it. */
 .glass {
-  background: rgba(255, 255, 255, 0.72);
-  backdrop-filter: saturate(180%) blur(20px);
-  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  background: #ffffff;
+  backdrop-filter: saturate(180%) blur(24px);
+  -webkit-backdrop-filter: saturate(180%) blur(24px);
+}
+
+/* Sections clear the sticky header when targeted via anchors. */
+section[id] {
+  scroll-margin-top: 64px;
 }
 
 /* Soft elevation for cards */

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,14 +5,6 @@
   --color-foreground: var(--fg);
 }
 
-/*
-  The default border color has changed to `currentColor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
-
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
-*/
 @layer base {
   *,
   ::after,
@@ -24,89 +16,186 @@
 }
 
 :root {
-  --bg: #f6f1e8;
-  --fg: #1c1712;
-  --fg-strong: #3a2d25;
-  --muted: #7d6b5c;
-  --soft: #5c4a3a;
-  --accent: #d97a4c;
-  --accent-soft: #f4c9a8;
-  --accent-glow: #f2b280;
-  --surface: #ffffff;
-  --surface-alt: #fffaf2;
-  --border: rgba(28, 23, 18, 0.12);
-  --on-dark: #f7efe6;
-  --on-dark-muted: #e6d7c6;
-  --grid: rgba(28, 23, 18, 0.08);
-  --grid-soft: rgba(28, 23, 18, 0.05);
-  --font-display: "Palatino Linotype", "Book Antiqua", "Times New Roman", serif;
+  --bg: #ffffff;
+  --bg-elevated: #ffffff;
+  --fg: #000000;
+  --fg-strong: #000000;
+  --muted: #86868b;
+  --soft: #515154;
+  --surface: #fbfbfd;
+  --surface-alt: #f5f5f7;
+  --surface-strong: #1d1d1f;
+  --border: rgba(0, 0, 0, 0.08);
+  --border-strong: rgba(0, 0, 0, 0.16);
+  --on-dark: #f5f5f7;
+  --on-dark-muted: #a1a1a6;
+  --accent: #000000;
+  --accent-soft: rgba(0, 0, 0, 0.06);
+  --accent-glow: rgba(0, 0, 0, 0.04);
+  --font-display:
+    -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", "Segoe UI",
+    Helvetica, Arial, sans-serif;
   --font-body:
-    "Avenir Next", Avenir, "Segoe UI", "Helvetica Neue", Helvetica, Arial,
-    sans-serif;
+    -apple-system, BlinkMacSystemFont, "SF Pro Text", "Inter", "Segoe UI",
+    Helvetica, Arial, sans-serif;
   --font-mono:
-    "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-    monospace;
+    "SF Mono", "SFMono-Regular", ui-monospace, Menlo, Monaco, Consolas,
+    "Liberation Mono", monospace;
+}
+
+html,
+body {
+  background: var(--bg);
+  color: var(--fg);
 }
 
 body {
-  color: var(--fg);
-  background: var(--bg);
-  font-family: var(--font-body), "IBM Plex Sans", sans-serif;
+  font-family: var(--font-body);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  letter-spacing: -0.011em;
 }
 
-.bg-grid {
-  background-image:
-    radial-gradient(circle at 1px 1px, var(--grid) 1px, transparent 0),
-    radial-gradient(circle at 1px 1px, var(--grid-soft) 1px, transparent 0);
-  background-size:
-    26px 26px,
-    60px 60px;
-  background-position:
-    0 0,
-    10px 12px;
+::selection {
+  background: var(--fg);
+  color: var(--bg);
 }
 
-.fade-up {
+/* Apple-style scroll reveal */
+.reveal {
   opacity: 0;
-  transform: translateY(18px);
-  animation: fadeUp 0.8s ease forwards;
+  transform: translateY(28px);
+  transition:
+    opacity 0.9s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform;
 }
 
-.delay-1 {
-  animation-delay: 0.1s;
+.reveal.in-view {
+  opacity: 1;
+  transform: translateY(0);
 }
 
-.delay-2 {
-  animation-delay: 0.2s;
+.reveal-delay-1 {
+  transition-delay: 0.08s;
 }
 
-.delay-3 {
-  animation-delay: 0.3s;
+.reveal-delay-2 {
+  transition-delay: 0.16s;
 }
 
-.float-slow {
-  animation: floatSlow 10s ease-in-out infinite;
+.reveal-delay-3 {
+  transition-delay: 0.24s;
 }
 
-.float-slower {
-  animation: floatSlow 14s ease-in-out infinite;
+.reveal-delay-4 {
+  transition-delay: 0.32s;
 }
 
-@keyframes fadeUp {
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+/* Apple-style header backdrop blur */
+.glass {
+  background: rgba(255, 255, 255, 0.72);
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
 }
 
-@keyframes floatSlow {
-  0%,
-  100% {
-    transform: translateY(0px);
-  }
-  50% {
-    transform: translateY(-18px);
-  }
+/* Soft elevation for cards */
+.card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  transition:
+    transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 0.3s ease,
+    box-shadow 0.4s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  border-color: var(--border-strong);
+  box-shadow: 0 20px 60px -30px rgba(0, 0, 0, 0.18);
+}
+
+/* Crisp hero halo (subtle, monochrome) */
+.halo {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(60% 60% at 20% 10%, rgba(0, 0, 0, 0.05), transparent 60%),
+    radial-gradient(50% 50% at 90% 80%, rgba(0, 0, 0, 0.04), transparent 60%);
+}
+
+/* Pill buttons (Apple-style) */
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.6rem;
+  border-radius: 980px;
+  background: var(--fg);
+  color: var(--bg);
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  transition:
+    transform 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.25s ease,
+    box-shadow 0.25s ease;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.04);
+}
+
+.btn-primary:hover {
+  transform: scale(1.03);
+  background: #1d1d1f;
+}
+
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.6rem;
+  border-radius: 980px;
+  background: var(--surface-alt);
+  color: var(--fg);
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  transition:
+    transform 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.25s ease;
+}
+
+.btn-secondary:hover {
+  transform: scale(1.03);
+  background: #ebebed;
+}
+
+/* Display type, Apple-style */
+.font-display {
+  font-family: var(--font-display);
+  letter-spacing: -0.035em;
+  font-weight: 600;
+}
+
+.font-body {
+  font-family: var(--font-body);
+}
+
+.font-mono {
+  font-family: var(--font-mono);
+  letter-spacing: 0;
+}
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -115,32 +204,10 @@ body {
   }
 }
 
-@media (max-width: 640px) {
-  .fade-up {
-    animation: none;
-    opacity: 1;
-    transform: none;
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .fade-up,
-  .float-slow,
-  .float-slower {
-    animation: none;
+  .reveal {
     opacity: 1;
     transform: none;
+    transition: none;
   }
-}
-
-.font-display {
-  font-family: var(--font-display), "Fraunces", "Times New Roman", serif;
-}
-
-.font-body {
-  font-family: var(--font-body), "IBM Plex Sans", sans-serif;
-}
-
-.font-mono {
-  font-family: var(--font-mono), "IBM Plex Mono", monospace;
 }

--- a/app/layout.test.tsx
+++ b/app/layout.test.tsx
@@ -1,0 +1,60 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@vercel/analytics/next', () => ({
+  __esModule: true,
+  Analytics: () => '__ANALYTICS_MARKER__',
+}));
+
+vi.mock('@vercel/speed-insights/next', () => ({
+  __esModule: true,
+  SpeedInsights: () => '__SPEED_INSIGHTS_MARKER__',
+}));
+
+const originalVercel = process.env.VERCEL;
+
+const loadLayout = async () => {
+  vi.resetModules();
+  const mod = await import('./layout');
+  return mod.default;
+};
+
+describe('RootLayout', () => {
+  afterEach(() => {
+    if (originalVercel === undefined) {
+      delete process.env.VERCEL;
+    } else {
+      process.env.VERCEL = originalVercel;
+    }
+  });
+
+  it('renders children inside <html lang="en"> when not running on Vercel', async () => {
+    delete process.env.VERCEL;
+    const RootLayout = await loadLayout();
+
+    const markup = renderToStaticMarkup(
+      <RootLayout>
+        <span data-testid="child">child</span>
+      </RootLayout>,
+    );
+
+    expect(markup).toContain('<html lang="en">');
+    expect(markup).toContain('<span data-testid="child">child</span>');
+    expect(markup).not.toContain('__ANALYTICS_MARKER__');
+    expect(markup).not.toContain('__SPEED_INSIGHTS_MARKER__');
+  });
+
+  it('mounts Vercel analytics components when VERCEL=1', async () => {
+    process.env.VERCEL = '1';
+    const RootLayout = await loadLayout();
+
+    const markup = renderToStaticMarkup(
+      <RootLayout>
+        <span data-testid="child">child</span>
+      </RootLayout>,
+    );
+
+    expect(markup).toContain('__ANALYTICS_MARKER__');
+    expect(markup).toContain('__SPEED_INSIGHTS_MARKER__');
+  });
+});

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -12,8 +12,22 @@ vi.mock('./components/technical-skills/TechnicalSkills', () => ({
   default: () => null,
 }));
 
+vi.mock('./components/reveal/RevealOnScroll', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const expectedNavLinks: { label: string; href: string }[] = [
+  { label: 'Overview', href: '#main-content' },
+  { label: 'About', href: '#about' },
+  { label: 'Impact', href: '#impact' },
+  { label: 'Skills', href: '#skills' },
+  { label: 'Current', href: '#current' },
+  { label: 'Contact', href: '#contact' },
+];
+
 describe('Page', () => {
-  it('should render key content and calls to action', () => {
+  it('renders the hero H1', () => {
     render(<Page />);
 
     expect(
@@ -22,11 +36,11 @@ describe('Page', () => {
         name: 'I build backend platforms teams trust in production.',
       }),
     ).toBeInTheDocument();
-    expect(
-      screen.getAllByRole('link', {
-        name: 'GitHub',
-      }).length,
-    ).toBeGreaterThan(0);
+  });
+
+  it('renders the section headings used by the redesigned layout', () => {
+    render(<Page />);
+
     expect(
       screen.getByRole('heading', {
         level: 3,
@@ -39,10 +53,71 @@ describe('Page', () => {
         name: 'What teams get when we work together',
       }),
     ).toBeInTheDocument();
+  });
+
+  it('renders the primary nav with all expected anchors', () => {
+    render(<Page />);
+
+    const nav = screen.getByRole('navigation', { name: 'Primary' });
+    for (const link of expectedNavLinks) {
+      const anchor = nav.querySelector(`a[href="${link.href}"]`);
+      expect(anchor, `nav link ${link.label}`).toBeInTheDocument();
+      expect(anchor).toHaveTextContent(link.label);
+    }
+  });
+
+  it('renders the skip-to-content link before nav', () => {
+    render(<Page />);
+
+    const skip = screen.getByRole('link', { name: 'Skip to content' });
+    expect(skip).toHaveAttribute('href', '#main-content');
+  });
+
+  it('renders every section landmark by id', () => {
+    const { container } = render(<Page />);
+
+    for (const id of [
+      'main-content',
+      'about',
+      'impact',
+      'skills',
+      'current',
+      'contact',
+    ]) {
+      expect(container.querySelector(`section#${id}`)).toBeInTheDocument();
+    }
+  });
+
+  it('renders the four profile snapshot rows', () => {
+    render(<Page />);
+
+    for (const label of ['Role', 'Stack', 'Now', 'Focus']) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('links to Benifex in a new tab from the current-role section', () => {
+    const { container } = render(<Page />);
+
+    const benifex = container.querySelector('a[href="https://benifex.com"]');
+    expect(benifex).toBeInTheDocument();
+    expect(benifex).toHaveAttribute('target', '_blank');
+    expect(benifex).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('exposes at least one GitHub call to action', () => {
+    render(<Page />);
+
     expect(
-      screen.queryByRole('link', {
-        name: 'Email me',
-      }),
+      screen.getAllByRole('link', { name: 'GitHub' }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('does not render an "Email me" link', () => {
+    render(<Page />);
+
+    expect(
+      screen.queryByRole('link', { name: 'Email me' }),
     ).not.toBeInTheDocument();
   });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,19 +59,19 @@ export default function Home() {
       </a>
 
       <header className="sticky top-0 z-30 glass border-b border-[color:var(--border)]">
-        <div className="container mx-auto flex h-12 items-center justify-between px-5 sm:px-8">
-          <span className="text-[15px] font-semibold tracking-tight text-[color:var(--fg)]">
+        <div className="container mx-auto flex h-12 items-center gap-3 px-4 sm:px-8">
+          <span className="hidden whitespace-nowrap text-[15px] font-semibold tracking-tight text-[color:var(--fg)] sm:inline">
             Matthew Carr
           </span>
           <nav
             aria-label="Primary"
-            className="flex items-center gap-1 overflow-x-auto text-[13px] font-medium text-[color:var(--soft)] sm:gap-2"
+            className="flex flex-1 items-center justify-end gap-0.5 overflow-x-auto whitespace-nowrap text-[12px] font-medium text-[color:var(--soft)] sm:gap-2 sm:text-[13px]"
           >
             {navLinks.map((link) => (
               <a
                 key={link.href}
                 href={link.href}
-                className="shrink-0 rounded-full px-3 py-1.5 transition-colors hover:text-[color:var(--fg)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--fg)]"
+                className="shrink-0 rounded-full px-2 py-1.5 transition-colors hover:text-[color:var(--fg)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--fg)] sm:px-3"
               >
                 {link.label}
               </a>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,147 +1,104 @@
 import Image from 'next/image';
 import Footer from './components/footer/Footer';
+import RevealOnScroll from './components/reveal/RevealOnScroll';
 import TechnicalSkills from './components/technical-skills/TechnicalSkills';
 
 const profileSnapshot = [
-  {
-    label: 'Role',
-    value: 'Senior Backend Engineer',
-  },
-  {
-    label: 'Core stack',
-    value: 'Java, Spring Boot, AWS/GCP, Kubernetes, Pub/Sub messaging',
-  },
-  {
-    label: 'Currently',
-    value: 'Benifex - Product-led development across multiple projects',
-  },
-  {
-    label: 'Focus',
-    value: 'Reliability, scalability, developer experience',
-  },
+  { label: 'Role', value: 'Senior Backend Engineer' },
+  { label: 'Stack', value: 'Java · Spring Boot · AWS · GCP · Kubernetes' },
+  { label: 'Now', value: 'Benifex' },
+  { label: 'Focus', value: 'Reliability. Scale. DX.' },
 ];
 
 const workPrinciples = [
   {
-    title: 'Design for change',
-    text: 'Interfaces and data models that absorb new product demands without rewrites.',
+    title: 'Design for change.',
+    text: 'Systems that absorb new demands without rewrites.',
   },
   {
-    title: 'Ship safely',
-    text: 'Progressive delivery, guardrails, and observability that make releases boring.',
+    title: 'Ship safely.',
+    text: 'Progressive delivery. Guardrails. Boring releases.',
   },
   {
-    title: 'Leave clear trails',
-    text: 'Readable code, sharp docs, and tooling that helps the next engineer move fast.',
+    title: 'Leave clear trails.',
+    text: 'Readable code. Sharp docs. Paved paths.',
   },
 ];
 
 const impactHighlights = [
   {
-    title: 'Reliability first',
-    text: 'I bias toward calm production behavior before optimization work.',
+    title: 'Reliability first.',
+    text: 'Calm production before clever optimization.',
   },
   {
-    title: 'Product-aware backend',
-    text: 'I map technical decisions to product outcomes and operational cost.',
+    title: 'Product-aware.',
+    text: 'Technical calls mapped to outcomes and cost.',
   },
-  {
-    title: 'Team acceleration',
-    text: 'I reduce cognitive load with conventions, documentation, and paved paths.',
-  },
+  { title: 'Team velocity.', text: 'Less cognitive load. Faster shipping.' },
 ];
 
 const navLinks = [
-  {
-    label: 'Overview',
-    href: '#main-content',
-  },
-  {
-    label: 'About',
-    href: '#about',
-  },
-  {
-    label: 'Impact',
-    href: '#impact',
-  },
-  {
-    label: 'Skills',
-    href: '#skills',
-  },
-  {
-    label: 'Current',
-    href: '#current',
-  },
-  {
-    label: 'Contact',
-    href: '#contact',
-  },
+  { label: 'Overview', href: '#main-content' },
+  { label: 'About', href: '#about' },
+  { label: 'Impact', href: '#impact' },
+  { label: 'Skills', href: '#skills' },
+  { label: 'Current', href: '#current' },
+  { label: 'Contact', href: '#contact' },
 ];
 
 export default function Home() {
   return (
-    <main className="min-h-screen bg-[color:var(--bg)] text-[color:var(--fg)] font-body selection:bg-[color:var(--accent-soft)] selection:text-[color:var(--fg)] bg-grid">
+    <main className="min-h-screen bg-[color:var(--bg)] text-[color:var(--fg)] font-body">
+      <RevealOnScroll />
+
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:left-6 focus:top-6 focus:z-50 focus:rounded-full focus:bg-[color:var(--fg)] focus:px-4 focus:py-2 focus:text-xs focus:font-semibold focus:uppercase focus:tracking-[0.3em] focus:text-[color:var(--on-dark)]"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-6 focus:top-6 focus:z-50 focus:rounded-full focus:bg-[color:var(--fg)] focus:px-4 focus:py-2 focus:text-xs focus:font-medium focus:text-[color:var(--on-dark)]"
       >
         Skip to content
       </a>
-      <header className="sticky top-0 z-30 border-b border-[color:var(--border)] bg-[color:var(--bg)] backdrop-blur">
-        <div className="container mx-auto flex flex-col gap-4 px-5 py-5 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex flex-wrap items-center gap-4">
-            <span className="font-mono text-xs uppercase tracking-[0.4em] text-[color:var(--fg)]">
-              Matthew Carr
-            </span>
-          </div>
-          <div className="flex w-full flex-col items-start gap-3 sm:w-auto sm:flex-row sm:items-center">
-            <nav
-              aria-label="Primary"
-              className="flex w-full -mx-2 items-center gap-2 overflow-x-auto text-[9px] font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)] sm:-mx-3 sm:w-auto sm:gap-3 sm:text-[10px] sm:tracking-[0.3em]"
-            >
-              {navLinks.map((link) => (
-                <a
-                  key={link.href}
-                  href={link.href}
-                  className="shrink-0 rounded-full px-2 py-2 transition hover:text-[color:var(--fg)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)] sm:px-3"
-                >
-                  {link.label}
-                </a>
-              ))}
-            </nav>
-          </div>
+
+      <header className="sticky top-0 z-30 glass border-b border-[color:var(--border)]">
+        <div className="container mx-auto flex h-12 items-center justify-between px-5 sm:px-8">
+          <span className="text-[15px] font-semibold tracking-tight text-[color:var(--fg)]">
+            Matthew Carr
+          </span>
+          <nav
+            aria-label="Primary"
+            className="flex items-center gap-1 overflow-x-auto text-[13px] font-medium text-[color:var(--soft)] sm:gap-2"
+          >
+            {navLinks.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                className="shrink-0 rounded-full px-3 py-1.5 transition-colors hover:text-[color:var(--fg)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--fg)]"
+              >
+                {link.label}
+              </a>
+            ))}
+          </nav>
         </div>
       </header>
 
+      {/* Hero */}
       <section id="main-content" className="relative overflow-hidden">
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -left-24 top-24 h-56 w-56 rounded-full bg-[color:var(--accent-soft)] opacity-70 blur-3xl float-slow"
-        />
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -right-10 top-10 h-40 w-40 rounded-full bg-[color:var(--accent-glow)] opacity-65 blur-3xl float-slower"
-        />
-        <div className="container mx-auto px-5 py-14 sm:px-6 sm:py-20">
-          <div className="grid items-center gap-10 lg:grid-cols-[1.08fr_0.92fr]">
-            <div className="space-y-8">
-              <p className="font-mono text-xs uppercase tracking-[0.4em] text-[color:var(--muted)] fade-up">
-                Overview
-              </p>
-              <h1 className="font-display text-4xl font-semibold leading-[1.08] text-[color:var(--fg)] sm:text-6xl fade-up delay-1">
+        <div aria-hidden="true" className="halo" />
+        <div className="container mx-auto px-5 pt-24 pb-28 sm:px-8 sm:pt-32 sm:pb-36">
+          <div className="grid items-center gap-16 lg:grid-cols-[1.1fr_0.9fr]">
+            <div>
+              <p className="eyebrow reveal">Senior Backend Engineer</p>
+              <h1 className="reveal reveal-delay-1 mt-6 font-display text-5xl leading-[1.02] text-[color:var(--fg)] sm:text-7xl">
                 I build backend platforms teams trust in production.
               </h1>
-              <p className="max-w-2xl text-base text-[color:var(--soft)] fade-up delay-2 sm:text-lg">
-                Senior backend engineer focused on reliability, scalability, and
-                developer experience. I help teams ship faster by making
-                architecture clearer and operations safer.
+              <p className="reveal reveal-delay-2 mt-6 max-w-xl text-lg text-[color:var(--soft)] sm:text-xl">
+                Reliable systems. Faster shipping. Cleaner architecture.
               </p>
-              <div className="flex flex-wrap gap-4 fade-up delay-3">
+              <div className="reveal reveal-delay-3 mt-10 flex flex-wrap gap-3">
                 <a
                   href="https://www.linkedin.com/in/matthew-carr-17012284"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="rounded-full bg-[color:var(--fg)] px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:-translate-y-0.5 hover:bg-[color:var(--fg-strong)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]"
+                  className="btn-primary"
                 >
                   LinkedIn
                 </a>
@@ -149,127 +106,103 @@ export default function Home() {
                   href="https://github.com/matthew-a-carr"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="rounded-full border border-[color:var(--border)] bg-[color:var(--surface)] px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--fg)] transition hover:-translate-y-0.5 hover:border-[color:var(--accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]"
+                  className="btn-secondary"
                 >
                   GitHub
                 </a>
               </div>
-              <div className="grid gap-3 sm:grid-cols-2 fade-up delay-3">
+              <div className="reveal reveal-delay-4 mt-12 grid gap-3 sm:grid-cols-2">
                 {profileSnapshot.map((row) => (
                   <div
                     key={row.label}
-                    className="rounded-2xl border border-[color:var(--border)] bg-[color:var(--surface)] px-4 py-3 shadow-[0_10px_30px_-26px_rgba(0,0,0,0.4)]"
+                    className="rounded-2xl border border-[color:var(--border)] bg-[color:var(--surface)] px-5 py-4"
                   >
-                    <p className="font-mono text-[10px] uppercase tracking-[0.32em] text-[color:var(--muted)]">
+                    <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-[color:var(--muted)]">
                       {row.label}
                     </p>
-                    <p className="mt-1 text-sm font-medium text-[color:var(--fg)]">
+                    <p className="mt-1 text-[15px] font-medium text-[color:var(--fg)]">
                       {row.value}
                     </p>
                   </div>
                 ))}
               </div>
             </div>
-            <div className="relative">
-              <div
-                aria-hidden="true"
-                className="absolute -inset-6 rounded-[32px] border border-[color:var(--accent)] opacity-50"
-              />
-              <div className="relative mx-auto max-w-[460px] rounded-[28px] border border-[color:var(--border)] bg-[color:var(--surface)] p-6 shadow-[0_32px_70px_-50px_rgba(0,0,0,0.45)]">
+
+            <div className="reveal reveal-delay-2 relative">
+              <div className="relative mx-auto max-w-[440px] overflow-hidden rounded-[32px] bg-[color:var(--surface-alt)]">
                 <Image
                   src="https://avatars.githubusercontent.com/u/76042279?v=4"
                   alt="Matthew Carr"
                   width={460}
                   height={460}
-                  className="h-auto w-full rounded-[20px]"
+                  className="h-auto w-full"
                 />
-                <div className="mt-5 flex items-center justify-between text-[10px] font-mono uppercase tracking-[0.32em] text-[color:var(--muted)]">
-                  <span>Backend</span>
-                  <span>Cloud</span>
-                  <span>DX</span>
-                </div>
               </div>
             </div>
           </div>
         </div>
       </section>
 
+      {/* About */}
       <section
         id="about"
-        className="border-t border-[color:var(--border)] py-14"
+        className="border-t border-[color:var(--border)] bg-[color:var(--surface-alt)]"
       >
-        <div className="container mx-auto px-5 sm:px-6">
-          <div className="grid gap-10 lg:grid-cols-[1fr_1fr]">
-            <div>
-              <p className="font-mono text-xs uppercase tracking-[0.4em] text-[color:var(--muted)]">
-                About
-              </p>
-              <h2 className="mt-3 font-display text-3xl sm:text-4xl">
-                Engineer mindset: stable systems, clear decisions, sharp
-                execution.
+        <div className="container mx-auto px-5 py-28 sm:px-8 sm:py-36">
+          <div className="grid gap-16 lg:grid-cols-[1fr_1fr]">
+            <div className="reveal">
+              <p className="eyebrow">About</p>
+              <h2 className="mt-5 font-display text-4xl text-[color:var(--fg)] sm:text-5xl">
+                Stable systems.
+                <br />
+                Sharp decisions.
               </h2>
-              <p className="mt-5 text-base text-[color:var(--soft)] sm:text-lg">
-                I work best on product-critical backend platforms where
-                reliability and delivery speed both matter. My bias is to keep
-                architecture understandable and production behavior predictable.
+              <p className="mt-6 max-w-md text-lg text-[color:var(--soft)]">
+                I work on product-critical backends where reliability and
+                delivery speed both matter.
               </p>
-              <p className="mt-4 text-base text-[color:var(--soft)] sm:text-lg">
-                I enjoy turning vague requirements into resilient services,
-                well-defined interfaces, and operational patterns teams can
-                trust.
+              <p className="mt-4 max-w-md text-lg text-[color:var(--soft)]">
+                Vague requirements become resilient services teams can trust.
               </p>
             </div>
-            <div className="rounded-3xl border border-[color:var(--border)] bg-[color:var(--surface)] p-6 shadow-[0_24px_60px_-44px_rgba(0,0,0,0.35)]">
-              <p className="font-mono text-xs uppercase tracking-[0.4em] text-[color:var(--muted)]">
-                How I work
-              </p>
-              <div className="mt-6 space-y-5">
-                {workPrinciples.map((principle, index) => (
-                  <article
-                    key={principle.title}
-                    className="rounded-2xl border border-[color:var(--border)] bg-[color:var(--surface-alt)] p-4"
-                  >
-                    <p className="font-mono text-[10px] uppercase tracking-[0.32em] text-[color:var(--muted)]">
-                      0{index + 1}
-                    </p>
-                    <h3 className="mt-2 text-lg font-medium text-[color:var(--fg)]">
-                      {principle.title}
-                    </h3>
-                    <p className="mt-2 text-sm text-[color:var(--soft)]">
-                      {principle.text}
-                    </p>
-                  </article>
-                ))}
-              </div>
+            <div className="reveal reveal-delay-1 space-y-3">
+              {workPrinciples.map((principle, index) => (
+                <article key={principle.title} className="card p-6">
+                  <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[color:var(--muted)]">
+                    0{index + 1}
+                  </p>
+                  <h3 className="mt-3 font-display text-xl text-[color:var(--fg)]">
+                    {principle.title}
+                  </h3>
+                  <p className="mt-2 text-[15px] text-[color:var(--soft)]">
+                    {principle.text}
+                  </p>
+                </article>
+              ))}
             </div>
           </div>
         </div>
       </section>
 
-      <section
-        id="impact"
-        className="border-t border-[color:var(--border)] py-14"
-      >
-        <div className="container mx-auto px-5 sm:px-6">
-          <div className="flex flex-col gap-2">
-            <p className="font-mono text-xs uppercase tracking-[0.4em] text-[color:var(--muted)]">
-              Impact
-            </p>
-            <h3 className="font-display text-3xl sm:text-4xl">
+      {/* Impact */}
+      <section id="impact" className="border-t border-[color:var(--border)]">
+        <div className="container mx-auto px-5 py-28 sm:px-8 sm:py-36">
+          <div className="reveal max-w-2xl">
+            <p className="eyebrow">Impact</p>
+            <h3 className="mt-5 font-display text-4xl text-[color:var(--fg)] sm:text-5xl">
               What teams get when we work together
             </h3>
           </div>
-          <div className="mt-8 grid gap-6 md:grid-cols-3">
-            {impactHighlights.map((item) => (
+          <div className="mt-16 grid gap-5 md:grid-cols-3">
+            {impactHighlights.map((item, index) => (
               <div
                 key={item.title}
-                className="rounded-3xl border border-[color:var(--border)] bg-[color:var(--surface)] p-6 shadow-[0_24px_60px_-44px_rgba(0,0,0,0.4)] transition hover:-translate-y-1 hover:border-[color:var(--accent)]"
+                className={`card reveal reveal-delay-${index + 1} p-8`}
               >
-                <div className="h-1 w-10 rounded-full bg-[color:var(--accent)]" />
-                <h3 className="mt-5 font-display text-2xl text-[color:var(--fg)]">
+                <h3 className="font-display text-2xl text-[color:var(--fg)]">
                   {item.title}
                 </h3>
-                <p className="mt-3 text-sm text-[color:var(--soft)]">
+                <p className="mt-3 text-[15px] text-[color:var(--soft)]">
                   {item.text}
                 </p>
               </div>
@@ -278,85 +211,77 @@ export default function Home() {
         </div>
       </section>
 
+      {/* Skills */}
       <section
         id="skills"
-        className="border-t border-[color:var(--border)] py-14"
+        className="border-t border-[color:var(--border)] bg-[color:var(--surface-alt)]"
       >
-        <div className="container mx-auto px-5 sm:px-6">
-          <div className="flex flex-col items-center text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.4em] text-[color:var(--muted)]">
-              Toolbox
-            </p>
-            <h3 className="mt-3 font-display text-3xl sm:text-4xl">
+        <div className="container mx-auto px-5 py-28 sm:px-8 sm:py-36">
+          <div className="reveal flex flex-col items-center text-center">
+            <p className="eyebrow">Toolbox</p>
+            <h3 className="mt-5 font-display text-4xl text-[color:var(--fg)] sm:text-5xl">
               Technical skills
             </h3>
           </div>
-          <div className="mt-10 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+          <div className="reveal reveal-delay-1 mt-16 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
             <TechnicalSkills />
           </div>
         </div>
       </section>
 
-      <section id="current" className="py-14">
-        <div className="container mx-auto px-5 sm:px-6">
-          <div className="rounded-3xl border border-[color:var(--border)] bg-[color:var(--surface)] p-8 shadow-[0_28px_70px_-52px_rgba(0,0,0,0.45)]">
-            <div className="flex flex-col items-start gap-6 md:flex-row md:items-center md:justify-between">
-              <div>
-                <p className="font-mono text-xs uppercase tracking-[0.4em] text-[color:var(--muted)]">
-                  Current role
-                </p>
-                <h3 className="mt-3 font-display text-2xl">
-                  Senior Backend Engineer at Benifex
-                </h3>
-                <p className="mt-3 text-sm text-[color:var(--soft)]">
-                  Product-led development across multiple projects, with a focus
-                  on reliability, scalability, and delivery speed.
-                </p>
-              </div>
-              <a
-                href="https://benifex.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Benifex"
-                className="flex items-center gap-4 rounded-2xl border border-[color:var(--border)] bg-[color:var(--surface)] px-4 py-3 text-sm font-medium text-[color:var(--fg)] shadow-sm transition hover:-translate-y-0.5 hover:border-[color:var(--accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]"
-              >
-                <Image
-                  src="/benifex-green.png"
-                  alt="Benifex logo"
-                  width={120}
-                  height={54}
-                  className="h-8 w-auto rounded-md"
-                />
-              </a>
+      {/* Current */}
+      <section id="current" className="border-t border-[color:var(--border)]">
+        <div className="container mx-auto px-5 py-28 sm:px-8 sm:py-36">
+          <div className="reveal card flex flex-col items-start gap-8 p-10 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="eyebrow">Current</p>
+              <h3 className="mt-5 font-display text-3xl text-[color:var(--fg)] sm:text-4xl">
+                Senior Backend Engineer at Benifex
+              </h3>
+              <p className="mt-3 max-w-md text-[15px] text-[color:var(--soft)]">
+                Product-led work across multiple projects.
+              </p>
             </div>
+            <a
+              href="https://benifex.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Benifex"
+              className="rounded-2xl border border-[color:var(--border)] bg-[color:var(--surface)] px-6 py-4 transition hover:border-[color:var(--border-strong)]"
+            >
+              <Image
+                src="/benifex-green.png"
+                alt="Benifex logo"
+                width={120}
+                height={54}
+                className="h-10 w-auto"
+              />
+            </a>
           </div>
         </div>
       </section>
 
-      <section
-        id="contact"
-        className="border-t border-[color:var(--border)] py-16"
-      >
-        <div className="container mx-auto px-5 sm:px-6">
-          <div className="rounded-[32px] border border-[color:var(--border)] bg-[color:var(--fg)] px-6 py-10 text-[color:var(--on-dark)] shadow-[0_30px_70px_-52px_rgba(0,0,0,0.6)] sm:px-8 sm:py-12">
-            <div className="grid gap-8 md:grid-cols-[1.1fr_0.9fr] md:items-center">
+      {/* Contact */}
+      <section id="contact" className="border-t border-[color:var(--border)]">
+        <div className="container mx-auto px-5 py-28 sm:px-8 sm:py-36">
+          <div className="reveal rounded-[32px] bg-[color:var(--surface-strong)] px-8 py-16 text-[color:var(--on-dark)] sm:px-16 sm:py-24">
+            <div className="grid gap-10 md:grid-cols-[1.1fr_0.9fr] md:items-center">
               <div>
-                <p className="font-mono text-xs uppercase tracking-[0.4em] text-[color:var(--accent-soft)]">
+                <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-[color:var(--on-dark-muted)]">
                   Let&apos;s connect
                 </p>
-                <h3 className="mt-4 font-display text-3xl sm:text-4xl">
-                  Not currently looking for new roles.
+                <h3 className="mt-5 font-display text-4xl sm:text-5xl">
+                  Not hiring myself out.
+                  <br />
+                  Always open to talk.
                 </h3>
-                <p className="mt-4 text-sm text-[color:var(--on-dark-muted)]">
-                  Happy to stay connected on GitHub and LinkedIn.
-                </p>
               </div>
-              <div className="flex flex-col gap-4 sm:flex-row md:justify-end">
+              <div className="flex flex-col gap-3 sm:flex-row md:justify-end">
                 <a
                   href="https://github.com/matthew-a-carr"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="rounded-full bg-[color:var(--accent-soft)] px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--fg)] transition hover:-translate-y-0.5 hover:bg-[color:var(--accent-glow)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]"
+                  className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-[15px] font-medium text-black transition hover:scale-[1.03]"
                 >
                   GitHub
                 </a>
@@ -364,7 +289,7 @@ export default function Home() {
                   href="https://www.linkedin.com/in/matthew-carr-17012284"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="rounded-full border border-[color:var(--accent-soft)] px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--on-dark)] transition hover:-translate-y-0.5 hover:border-[color:var(--accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]"
+                  className="inline-flex items-center justify-center rounded-full border border-white/30 px-6 py-3 text-[15px] font-medium text-white transition hover:scale-[1.03] hover:border-white/60"
                 >
                   LinkedIn
                 </a>
@@ -374,9 +299,9 @@ export default function Home() {
         </div>
       </section>
 
-      <footer className="pb-16">
-        <div className="container mx-auto px-5 sm:px-6">
-          <div className="flex flex-wrap justify-center gap-4">
+      <footer className="border-t border-[color:var(--border)] py-12">
+        <div className="container mx-auto px-5 sm:px-8">
+          <div className="flex flex-wrap justify-center gap-3">
             <Footer />
           </div>
         </div>

--- a/integration/_utils.ts
+++ b/integration/_utils.ts
@@ -1,0 +1,17 @@
+import { expect, type Page } from '@playwright/test';
+
+export const sections = [
+  { label: 'Overview', id: 'main-content' },
+  { label: 'About', id: 'about' },
+  { label: 'Impact', id: 'impact' },
+  { label: 'Skills', id: 'skills' },
+  { label: 'Current', id: 'current' },
+  { label: 'Contact', id: 'contact' },
+] as const;
+
+export const gotoHome = async (page: Page, path = '/') => {
+  const response = await page.goto(path);
+
+  expect(response?.ok()).toBeTruthy();
+  await expect(page.locator('main')).toBeVisible();
+};

--- a/integration/accessibility.spec.ts
+++ b/integration/accessibility.spec.ts
@@ -7,6 +7,19 @@ test('home page has no serious or critical accessibility violations', async ({
 }) => {
   await gotoHome(page);
 
+  // Reveal animations start at opacity:0; disable transitions and force
+  // the rested state so axe scans what the user actually sees rather than
+  // the mid-animation frame.
+  await page.addStyleTag({
+    content:
+      '.reveal { opacity: 1 !important; transform: none !important; transition: none !important; }',
+  });
+  await page.evaluate(() => {
+    for (const el of document.querySelectorAll('.reveal')) {
+      el.classList.add('in-view');
+    }
+  });
+
   const results = await new AxeBuilder({ page })
     .withTags(['wcag2a', 'wcag2aa'])
     .analyze();

--- a/integration/accessibility.spec.ts
+++ b/integration/accessibility.spec.ts
@@ -1,0 +1,27 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+import { gotoHome } from './_utils';
+
+test('home page has no serious or critical accessibility violations', async ({
+  page,
+}) => {
+  await gotoHome(page);
+
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa'])
+    .analyze();
+
+  const blocking = results.violations.filter(
+    (violation) =>
+      violation.impact === 'serious' || violation.impact === 'critical',
+  );
+
+  expect(
+    blocking,
+    blocking
+      .map(
+        (v) => `${v.id} (${v.impact}): ${v.help} — ${v.nodes.length} node(s)`,
+      )
+      .join('\n'),
+  ).toEqual([]);
+});

--- a/integration/page.spec.ts
+++ b/integration/page.spec.ts
@@ -116,19 +116,31 @@ test('hash deep-link on initial load scrolls to the target section', async ({
 }) => {
   await gotoHome(page, '/#impact');
 
-  await page.waitForTimeout(300);
+  // Wait for smooth-scroll to settle: poll until scrollY stays stable.
+  await page.waitForFunction(
+    () => {
+      const w = window as unknown as {
+        __lastScroll?: number;
+        __stableTicks?: number;
+      };
+      if (w.__lastScroll === window.scrollY) {
+        w.__stableTicks = (w.__stableTicks ?? 0) + 1;
+        return (w.__stableTicks ?? 0) >= 3;
+      }
+      w.__lastScroll = window.scrollY;
+      w.__stableTicks = 0;
+      return false;
+    },
+    { polling: 100, timeout: 5000 },
+  );
 
-  const { scrollY, impactTop } = await page.evaluate(() => {
-    const impact = document.getElementById('impact');
-    return {
-      scrollY: window.scrollY,
-      impactTop: impact
-        ? impact.getBoundingClientRect().top + window.scrollY
-        : 0,
-    };
-  });
+  const viewportTop = await page
+    .locator('#impact')
+    .evaluate((el) => el.getBoundingClientRect().top);
 
-  expect(scrollY).toBeGreaterThan(impactTop - 200);
+  // The impact section should be at or near the top of the viewport.
+  expect(viewportTop).toBeGreaterThanOrEqual(0);
+  expect(viewportTop).toBeLessThan(200);
 });
 
 test('sticky header remains visible after scrolling to the bottom', async ({
@@ -160,19 +172,26 @@ test('hero avatar and Benifex logo load successfully', async ({ page }) => {
 
   for (const alt of ['Matthew Carr', 'Benifex logo']) {
     const img = page.locator(`img[alt="${alt}"]`).first();
+    await img.scrollIntoViewIfNeeded();
     await expect(img).toBeVisible();
-    const naturalWidth = await img.evaluate(
-      (node) => (node as HTMLImageElement).naturalWidth,
-    );
-    expect(naturalWidth, `${alt} naturalWidth`).toBeGreaterThan(0);
+    // Next.js lazy-loads images; wait for the natural width to populate.
+    await expect
+      .poll(
+        async () =>
+          img.evaluate((node) => (node as HTMLImageElement).naturalWidth),
+        { timeout: 5000 },
+      )
+      .toBeGreaterThan(0);
   }
 });
 
-test('every section has a heading at level h2 or h3', async ({ page }) => {
+test('every section has at least one heading', async ({ page }) => {
   await gotoHome(page);
 
   for (const section of sections) {
-    const headings = page.locator(`#${section.id} h2, #${section.id} h3`);
+    const headings = page.locator(
+      `#${section.id} h1, #${section.id} h2, #${section.id} h3`,
+    );
     expect(
       await headings.count(),
       `section #${section.id} should have a heading`,
@@ -196,6 +215,95 @@ test('footer exposes GitHub and LinkedIn links', async ({ page }) => {
   const footer = page.locator('footer').last();
   await expect(footer.getByRole('link', { name: 'GitHub' })).toBeVisible();
   await expect(footer.getByRole('link', { name: 'LinkedIn' })).toBeVisible();
+});
+
+test('sticky header is opaque enough to obscure content under it', async ({
+  page,
+}) => {
+  await gotoHome(page);
+  await page.evaluate(() => window.scrollTo(0, 2000));
+  await page.waitForTimeout(200);
+
+  const headerBg = await page
+    .locator('header')
+    .first()
+    .evaluate((el) => getComputedStyle(el).backgroundColor);
+
+  const match = headerBg.match(/rgba?\(([^)]+)\)/);
+  expect(match, `unparseable backgroundColor: ${headerBg}`).not.toBeNull();
+  const parts = (match?.[1] ?? '')
+    .split(',')
+    .map((s) => Number.parseFloat(s.trim()));
+  const alpha = parts.length === 4 ? parts[3] : 1;
+
+  expect(
+    alpha,
+    `header alpha was ${alpha} (${headerBg})`,
+  ).toBeGreaterThanOrEqual(0.9);
+});
+
+test('section anchors leave room for the sticky header', async ({ page }) => {
+  await gotoHome(page);
+
+  const headerHeight = await page
+    .locator('header')
+    .first()
+    .evaluate((el) => (el as HTMLElement).getBoundingClientRect().height);
+
+  for (const section of sections.filter((s) => s.id !== 'main-content')) {
+    const scrollMargin = await page
+      .locator(`#${section.id}`)
+      .evaluate((el) =>
+        Number.parseFloat(getComputedStyle(el).scrollMarginTop),
+      );
+
+    expect(
+      scrollMargin,
+      `#${section.id} scroll-margin-top (was ${scrollMargin}px, header ${headerHeight}px)`,
+    ).toBeGreaterThanOrEqual(headerHeight);
+  }
+});
+
+test('mobile header keeps the brand on a single line', async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await gotoHome(page);
+
+  const brand = page
+    .locator('header span', { hasText: 'Matthew Carr' })
+    .first();
+
+  if ((await brand.count()) === 0) {
+    // It's also acceptable to hide the brand on mobile.
+    return;
+  }
+
+  const lines = await brand.evaluate((el) => {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    return range.getClientRects().length;
+  });
+  expect(lines, 'brand line count').toBeLessThanOrEqual(1);
+});
+
+test('mobile primary nav does not push content beyond the viewport', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await gotoHome(page);
+
+  const overflow = await page.evaluate(
+    () =>
+      document.documentElement.scrollWidth -
+      document.documentElement.clientWidth,
+  );
+  expect(
+    overflow,
+    `document overflows viewport by ${overflow}px`,
+  ).toBeLessThanOrEqual(0);
+
+  const nav = page.getByRole('navigation', { name: 'Primary' });
+  const overflowX = await nav.evaluate((el) => getComputedStyle(el).overflowX);
+  expect(['auto', 'scroll']).toContain(overflowX);
 });
 
 test('keyboard navigation reaches every primary nav link', async ({ page }) => {

--- a/integration/page.spec.ts
+++ b/integration/page.spec.ts
@@ -1,20 +1,5 @@
-import { expect, type Page, test } from '@playwright/test';
-
-const sections = [
-  { label: 'Overview', id: 'main-content' },
-  { label: 'About', id: 'about' },
-  { label: 'Impact', id: 'impact' },
-  { label: 'Skills', id: 'skills' },
-  { label: 'Current', id: 'current' },
-  { label: 'Contact', id: 'contact' },
-];
-
-const gotoHome = async (page: Page) => {
-  const response = await page.goto('/');
-
-  expect(response?.ok()).toBeTruthy();
-  await expect(page.locator('main')).toBeVisible();
-};
+import { expect, test } from '@playwright/test';
+import { gotoHome, sections } from './_utils';
 
 test('home page renders without console errors', async ({ page }, testInfo) => {
   const consoleErrors: string[] = [];
@@ -96,4 +81,133 @@ test('external links open in a new tab', async ({ page }) => {
   await expect(
     page.locator('a[href="https://benifex.com"]').first(),
   ).toHaveAttribute('target', '_blank');
+});
+
+test('every external link carries rel="noopener noreferrer"', async ({
+  page,
+}) => {
+  await gotoHome(page);
+
+  const externalAnchors = page.locator('a[target="_blank"]');
+  const count = await externalAnchors.count();
+  expect(count).toBeGreaterThan(0);
+
+  for (let i = 0; i < count; i++) {
+    const rel = (await externalAnchors.nth(i).getAttribute('rel')) ?? '';
+    expect(rel, `anchor index ${i} missing rel`).toContain('noopener');
+    expect(rel, `anchor index ${i} missing rel`).toContain('noreferrer');
+  }
+});
+
+test('skip-to-content link becomes visible on focus and targets the hero', async ({
+  page,
+}) => {
+  await gotoHome(page);
+
+  const skipLink = page.getByRole('link', { name: 'Skip to content' });
+  await expect(skipLink).toHaveAttribute('href', '#main-content');
+
+  await skipLink.focus();
+  await expect(skipLink).toBeVisible();
+});
+
+test('hash deep-link on initial load scrolls to the target section', async ({
+  page,
+}) => {
+  await gotoHome(page, '/#impact');
+
+  await page.waitForTimeout(300);
+
+  const { scrollY, impactTop } = await page.evaluate(() => {
+    const impact = document.getElementById('impact');
+    return {
+      scrollY: window.scrollY,
+      impactTop: impact
+        ? impact.getBoundingClientRect().top + window.scrollY
+        : 0,
+    };
+  });
+
+  expect(scrollY).toBeGreaterThan(impactTop - 200);
+});
+
+test('sticky header remains visible after scrolling to the bottom', async ({
+  page,
+}) => {
+  await gotoHome(page);
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await page.waitForTimeout(200);
+
+  const header = page.locator('header').first();
+  await expect(header).toBeVisible();
+});
+
+test('reveal-on-scroll elements gain the in-view class after scrolling', async ({
+  page,
+}) => {
+  await gotoHome(page);
+
+  await page.locator('#impact').scrollIntoViewIfNeeded();
+  await page.waitForTimeout(800);
+
+  const inViewCount = await page.locator('.reveal.in-view').count();
+  expect(inViewCount).toBeGreaterThan(0);
+});
+
+test('hero avatar and Benifex logo load successfully', async ({ page }) => {
+  await gotoHome(page);
+
+  for (const alt of ['Matthew Carr', 'Benifex logo']) {
+    const img = page.locator(`img[alt="${alt}"]`).first();
+    await expect(img).toBeVisible();
+    const naturalWidth = await img.evaluate(
+      (node) => (node as HTMLImageElement).naturalWidth,
+    );
+    expect(naturalWidth, `${alt} naturalWidth`).toBeGreaterThan(0);
+  }
+});
+
+test('every section has a heading at level h2 or h3', async ({ page }) => {
+  await gotoHome(page);
+
+  for (const section of sections) {
+    const headings = page.locator(`#${section.id} h2, #${section.id} h3`);
+    expect(
+      await headings.count(),
+      `section #${section.id} should have a heading`,
+    ).toBeGreaterThan(0);
+  }
+});
+
+test('page title and meta description match the brand', async ({ page }) => {
+  await gotoHome(page);
+
+  await expect(page).toHaveTitle('Matthew Carr');
+  const description = await page
+    .locator('meta[name="description"]')
+    .getAttribute('content');
+  expect(description).toBe('About me');
+});
+
+test('footer exposes GitHub and LinkedIn links', async ({ page }) => {
+  await gotoHome(page);
+
+  const footer = page.locator('footer').last();
+  await expect(footer.getByRole('link', { name: 'GitHub' })).toBeVisible();
+  await expect(footer.getByRole('link', { name: 'LinkedIn' })).toBeVisible();
+});
+
+test('keyboard navigation reaches every primary nav link', async ({ page }) => {
+  await gotoHome(page);
+
+  const primaryNav = page.getByRole('navigation', { name: 'Primary' });
+  const navLinks = primaryNav.locator('a');
+  const total = await navLinks.count();
+  expect(total).toBe(sections.length);
+
+  for (let i = 0; i < total; i++) {
+    await navLinks.nth(i).focus();
+    await expect(navLinks.nth(i)).toBeFocused();
+  }
 });

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-icons": "5.5.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@biomejs/biome": "^2.4.2",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,5 +29,17 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 7'] },
+    },
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
         specifier: 5.5.0
         version: 5.5.0(react@19.2.4)
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.3
+        version: 4.11.3(playwright-core@1.58.2)
       '@biomejs/biome':
         specifier: ^2.4.2
         version: 2.4.6
@@ -112,6 +115,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
@@ -1086,6 +1094,10 @@ packages:
   ast-v8-to-istanbul@0.3.12:
     resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
+
   baseline-browser-mapping@2.9.18:
     resolution: {integrity: sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA==}
     hasBin: true
@@ -1857,6 +1869,11 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@axe-core/playwright@4.11.3(playwright-core@1.58.2)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.58.2
+
   '@babel/code-frame@7.28.6':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -2601,6 +2618,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  axe-core@4.11.4: {}
 
   baseline-browser-mapping@2.9.18: {}
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,11 @@
 import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
 import React from 'react';
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
 
 vi.mock('next/image', () => ({
   __esModule: true,


### PR DESCRIPTION
Move to a monochrome palette (white/black with neutral grays), tighten
copy across the page so it reads punchier, and add Apple-style touches:
SF system font stack, frosted-glass sticky header, scroll-reveal
IntersectionObserver animations, pill buttons with subtle scale on hover,
larger display type with tight tracking, and roomier section spacing.

https://claude.ai/code/session_01ME3678Aw9HJma2g5dXxvq3