### PR TITLE
docs: rename lifecycle labels claude:* → ai:* (vendor-neutral)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ GitHub issues on `matthew-a-carr/about` (via `gh`). See `docs/agents/issue-track
 
 ### Workflow labels
 
-travel-planner's `claude:*` lifecycle labels (not yet wired up here). See `docs/agents/workflow-labels.md`.
+travel-planner's `ai:*` lifecycle labels (not yet wired up here). See `docs/agents/workflow-labels.md`.
 
 ### Domain docs
 

--- a/docs/agents/workflow-labels.md
+++ b/docs/agents/workflow-labels.md
@@ -2,17 +2,17 @@
 
 The autonomous lifecycle is label-driven: opening or merging an issue/PR with a
 given label fires the matching routine/skill. This repo follows travel-planner's
-`claude:*` vocabulary (ADR 057) so it runs the same flow. The routines are not
+`ai:*` vocabulary (ADR 057) so it runs the same flow. The routines are not
 wired up in `about` yet — these are the labels to create/apply when they are.
 
 | Lifecycle role        | Label              | Fires / means                                |
 | --------------------- | ------------------ | -------------------------------------------- |
-| plan a SPEC           | `claude:plan`      | `draft-spec` — issue → SPEC PR               |
-| plan an EPIC          | `claude:plan-epic` | `draft-epic` — issue → EPIC PR               |
-| revise from feedback  | `claude:revise-now`| `revise-spec` — rewrite spec/epic PR         |
-| implement             | `claude:implement` | `implement-spec` — merged spec PR → impl PR  |
-| ready for review      | `claude:done`      | implementation PR awaiting human review      |
-| blocked               | `claude:blocked`   | a routine hit a wall; needs a human          |
-| already planned       | `claude:planned`   | issue already drafted; routine won't redo it |
+| plan a SPEC           | `ai:plan`      | `draft-spec` — issue → SPEC PR               |
+| plan an EPIC          | `ai:plan-epic` | `draft-epic` — issue → EPIC PR               |
+| revise from feedback  | `ai:revise-now`| `revise-spec` — rewrite spec/epic PR         |
+| implement             | `ai:implement` | `implement-spec` — merged spec PR → impl PR  |
+| ready for review      | `ai:done`      | implementation PR awaiting human review      |
+| blocked               | `ai:blocked`   | a routine hit a wall; needs a human          |
+| already planned       | `ai:planned`   | issue already drafted; routine won't redo it |
 
 When a skill mentions a lifecycle role, apply the corresponding label string.


### PR DESCRIPTION
Vendor-neutral rename of the lifecycle labels from `claude:*` to `ai:*`, matching the travel-planner rename. Follows the wiring PR (#282).

1. `docs/agents/workflow-labels.md` + `AGENTS.md`: lifecycle label vocabulary now `ai:*`.

Note: about doesn't run the routines yet, so this is documentation of the intended labels for when it adopts the lifecycle.

https://claude.ai/code/session_01G6zWbJgQkMRtd9M3ry43CB

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6zWbJgQkMRtd9M3ry43CB)_